### PR TITLE
Fix bugs in README and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ English / [中文](https://github.com/PioneerIncubator/betterGo/blob/master/READ
 
 # betterGo
 
-Better Go implement parts that I think Golang missed
+betterGo implement parts that I think Golang missed
 
 ## Real Generic
 
 Provide the real interface{} to you so that you can use it in your code.
-Before deployment, just use translator to generate specify type code, in which way will not affect your performance.
+Before deployment, just use translator to generate specific type code, in which way will not affect your performance.
 
 Here are all generic functions:
 * enum.Reduce
@@ -15,7 +15,7 @@ Here are all generic functions:
 
 ### Implementation
 
-Use go ast to analyse your code where using generic functions, generate specify function for your types and replace your original call.
+Use go ast to analyse your code where using generic functions, generate specific function for your types and replace your original call expressions.
 
 ### What I actually do
 
@@ -50,9 +50,10 @@ The following ways are often used in Go in order to implement generics:
    Cons: Considerable runtime overhead, and no compile-time type checking.
 
 4. Code generation
-   Pros: Extremely clean code, compile-time type checking, no runtime overhead
-
-   Cons: Requires third-party libraries, larger compiled binaries
+   
+Pros: Extremely clean code, compile-time type checking, no runtime overhead.
+   
+   Cons: Requires third-party libraries, larger compiled binaries.
 
 `betterGo` is a generic implementation of `code generation`.
 
@@ -62,7 +63,7 @@ If you want to use `betterGo` to implement generics by automatically generating 
 
 There are test cases in the project, for example, the code that needs to be generic is `test/map/map.go`, if you want to use the `interface{}` function, just `enum.Map`.
 
-If you want to generate a function of a specific type, run this line of commands: `go run main.go -w -f test/map/map.go`
+If you want to generate a function of a specific type, run this command: `go run main.go -w -f test/map/map.go`
 
 Then you'll find that `test/map/map.go` has changed, `enum.Map` has become `enum.MapOriginFn(origin, fn)`.
 
@@ -90,7 +91,7 @@ If you want to start with theory, you can find some information on `AST` and stu
 
 3. When a statement containing the value/type of a variable  (`AssignStmt`, `FuncDecl`) is analyzed, the value and type of the variable are recorded and a mapping between them is established so that the type of the variable can be obtained from the variable name in subsequent sessions.
 
-4. When a function call expression (`CallExpr`) is found, it is checked whether the function is provided by us, and if it is, the code that deals specifically with that type is generated from the type corresponding to the argument namerecorded in the previous step and stored in the specified path (if code of the same type has already been generated before, it is not repeated).
+4. When a function call expression (`CallExpr`) is found, it is checked whether the function is provided by us, and if it is, the code that deals specifically with that type is generated from the type corresponding to the argument name recorded in the previous step and stored in the specified path (if code of the same type has already been generated before, it is not repeated).
 
 5. Replaces the original function call expression in the original code with a new function call expression that calls the newly generated function from the previous step, and updates the import package.
 

--- a/test/reduce/main.go
+++ b/test/reduce/main.go
@@ -39,7 +39,7 @@ func main() {
 	floatOut := enum.Reduce(c, func(x, y float32) (z float32) {
 		z = x * y
 		return
-	}, 1).(float32)
+	}, 1.0).(float32)
 	var floatExpect float32 = 1.0
 	for i := range c {
 		floatExpect *= c[i]

--- a/translator/expr.go
+++ b/translator/expr.go
@@ -20,13 +20,10 @@ func ExtractParamsTypeAndName(fset *token.FileSet, listOfArgs []ast.Expr) (strin
 		argname = utils.IncrementString(argname, "", 1)
 		switch x := arg.(type) {
 		case *ast.BasicLit:
-			switch x.Kind {
-			case token.INT:
-				argVarName := x.Value
-				listOfArgVarNames = append(listOfArgVarNames, argVarName)
-				listOfArgTypes = append(listOfArgTypes, "int")
-				paramsType = fmt.Sprintf("%s %s int", paramsType, argname)
-			}
+			argVarName := x.Value
+			listOfArgVarNames = append(listOfArgVarNames, argVarName)
+			listOfArgTypes = append(listOfArgTypes, GetBasicLitType(x))
+			paramsType = fmt.Sprintf("%s %s %s", paramsType, argname, GetBasicLitType(x))
 		case *ast.Ident:
 			argVarName := x.Name
 			listOfArgVarNames = append(listOfArgVarNames, argVarName)

--- a/translator/expr.go
+++ b/translator/expr.go
@@ -76,6 +76,9 @@ func ExtractParamsTypeAndName(fset *token.FileSet, listOfArgs []ast.Expr) (strin
 
 func GetExprStr(fset *token.FileSet, expr interface{}) string {
 	name := new(bytes.Buffer)
-	printer.Fprint(name, fset, expr)
+	err := printer.Fprint(name, fset, expr)
+	if err != nil {
+		panic(err)
+	}
 	return name.String()
 }

--- a/translator/gen_fun_call.go
+++ b/translator/gen_fun_call.go
@@ -12,10 +12,7 @@ func extractParamsName(listOfArgs []ast.Expr) string {
 	for _, arg := range listOfArgs {
 		switch x := arg.(type) {
 		case *ast.BasicLit:
-			switch x.Kind {
-			case token.INT:
-				paramsName = strings.Title(fmt.Sprintf("%s int", paramsName))
-			}
+			paramsName = strings.Title(fmt.Sprintf("%s %s", paramsName, GetBasicLitType(x)))
 		case *ast.Ident:
 			paramsName = fmt.Sprintf("%s %s", paramsName, strings.Title(x.Name))
 		}

--- a/translator/var.go
+++ b/translator/var.go
@@ -42,7 +42,7 @@ func RecordAssignVarType(fset *token.FileSet, ret *ast.AssignStmt) {
 			}
 			if assignType == types.BasicLitStr {
 				expr := ret.Rhs[i].(*ast.BasicLit)
-				assignType = getBasicLitType(expr)
+				assignType = GetBasicLitType(expr)
 			}
 
 			fmt.Println("-- assignVar ", assignVar, " assign type ...... ", assignType)
@@ -53,7 +53,7 @@ func RecordAssignVarType(fset *token.FileSet, ret *ast.AssignStmt) {
 	fmt.Println("---------------------")
 }
 
-func getBasicLitType(expr *ast.BasicLit) string {
+func GetBasicLitType(expr *ast.BasicLit) string {
 	switch expr.Kind {
 	case token.INT:
 		return "int"
@@ -80,7 +80,7 @@ func RecordDeclVarType(fset *token.FileSet, ret *ast.ValueSpec) {
 			declVarType := reflectType(fset, value)
 			fmt.Println("-- declVar ", declVar, " declare type ...... ", declVarType)
 			if declVarType == types.BasicLitStr {
-				declVarType = getBasicLitType(value.(*ast.BasicLit))
+				declVarType = GetBasicLitType(value.(*ast.BasicLit))
 			}
 			variableType[declVar.Name] = declVarType
 			fmt.Println("[variableType] is ", variableType)


### PR DESCRIPTION
1. Fix some typos in README
2. DRY principle: Reuse all code that specify the type of `ast.BasicLit` by token.
3. Add error handling